### PR TITLE
Add sticky navbar on scroll

### DIFF
--- a/iglesia-remedios/src/components/Navbar.tsx
+++ b/iglesia-remedios/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 const NavLinks = [
   { name: "Inicio", href: "/" },
@@ -9,8 +9,24 @@ const NavLinks = [
 ];
 
 const Navbar: React.FC = () => {
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setScrolled(window.scrollY > 0);
+    };
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
   return (
-    <nav className="flex items-center justify-between px-8 py-4 bg-transparent text-yellow-600">
+    <nav
+      className={`${
+        scrolled
+          ? "bg-white/80 shadow-lg py-6"
+          : "bg-transparent py-3"
+      } fixed top-0 left-0 w-full flex items-center justify-between px-8 text-yellow-600 transition-all duration-300 backdrop-blur`}
+    >
       <div className="font-cinzel font-bold text-2xl">Iglesia Remedios</div>
 
       <ul className="flex space-x-6 font-cinzel">


### PR DESCRIPTION
## Summary
- make navbar fixed and transparent when page loads
- enlarge and add background when scrolled

## Testing
- `npm run lint` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687bb4f5adc0832cb7f90af42e3b620f